### PR TITLE
feat: ajout tp-08-gerer_des_services

### DIFF
--- a/tp-08-gerer_des_services/README.md
+++ b/tp-08-gerer_des_services/README.md
@@ -1,0 +1,154 @@
+# TP 08 : Gérer des services
+
+## Introduction
+
+`Systemd` est le gestionnaire de services systèmes de GNU/Linux.  
+Il permet d’assurer le démarrage, l’arrêt et l’ordonnancement entre les divers services qui sont
+exécutés sur le système.
+
+Il utilise des fichiers descriptifs au format `ini` pour savoir quoi, quand et comment démarrer/arrêter.
+
+Lisez les documentations :
+- [Gestion des Services Linux avec systemctl](https://blog.stephane-robert.info/docs/admin-serveurs/linux/services/)
+---
+
+## 📚 Résumé de la documentation technique
+
+- **Nom** : `systemctl`
+- **Type** : Gestion de services système
+- **Fonctionnalités principales** :
+    - Connaître l’état d’un service système
+    - Arrêt et démarrage de services système
+    - Ordonnancement des services (notions de dépendences)
+
+- **Nom** : `journalctl`
+- **Type** : Gestion des journaux système
+- **Fonctionnalités principales** :
+    - Consulter les journaux système
+    - Consulter les journaux d’un service système donné
+
+## Prérequis
+
+Pour pouvoir manipuler un service système sans impact sur les services essentiels de la machine, installez `haveged`.
+
+`Haveged` est un générateur d’entropie pour les systèmes Linux.  
+Il n’est pas vital au fonctionnement du système, et ne consomme quasiment pas de ressources.  
+Son installation permettra de manipuler `systemctl` et `journalctl` sans risquer de causer de problèmes fonctionnels
+à votre système.
+
+Pour installer `haveged`, exécuter la commande suivante :
+
+```shell
+sudo apt install haveged
+```
+
+## Tutoriels
+
+### Exercice 1 : Dans quel état est le service ?
+
+- **Objectif** : Vérifier l’état d’un service géré par `systemd`
+
+**Étapes :**
+
+1. Obtenez les informations sur le service `haveged` :
+  ```shell
+  systemctl status haveged.service
+  ```
+
+2. Vérifiez l’état du service au travers de la ligne `Active:` :
+  ```text
+  Active: active (running) since ...
+  ```
+
+
+3. Comparez les informations entre l’exécution en utilisateur standard et en root :
+  ```test
+  systemctl status haveged.service
+  sudo systemctl status haveged.service
+  ```
+
+4. Arrêtez le service `haveged` avec la commande :
+  ```shell
+  sudo systemctl stop haveged
+  ```
+
+5. Analysez l’état du service. Vous devriez voir la ligne `Active` qui ressemble à cela :
+  ```text
+  Active: inactive (dead) since ...
+  ```
+
+6. Redémarrez le service `haveged` avec la commande :
+  ```text
+  sudo systemctl start haveged
+  ```
+
+- **Commandes utilisées** :
+    - `systemctl` : permet d’interrager avec le gestionnaire de service `systemd`
+
+### Exercice 2 : Comment se comporte mon service ?
+
+- **Objectif** : Comprendre comment et quand est démarré un service
+
+**Étapes :**
+
+1. Vérifier l’état au démarrage du système d’un service avec la commande :
+  ```shell
+  systemctl is-enabled haveged.service
+  ```
+
+2. Vérifier les services qui doivent être lancé avant le service que l’on consulte via `systemctl` :
+  ```shell
+  systemctl list-dependencies --after haveged.service
+  ```
+
+3. Vérifier les services qui doivent être lancé après le  service que l’on consulte via `systemctl` :
+  ```shell
+  systemctl list-dependencies --before haveged.service
+  ```
+
+4. Vérifier le contenu de la configuration du service (vérifier les directives `After`, `Before` et `WantedBy`):
+  ```shell
+  systemctl cat haveged.service
+  ```
+
+5. Désactiver un service au démarrage du système avec la commande :
+  ```shell
+  sudo systemctl disable haveged.service
+  ```
+
+6. Vérifier l’état au démarrage du système du service :
+  ```shell
+  systemctl is-enabled haveged.service
+  ```
+
+7. Réactiver le service au démarrage du système :
+  ```shell
+  systemctl enable haveged.service
+  ```
+
+### Exercice 3 : Les journaux d’un service
+
+- **Objectif** : Consulter les journaux d’un service
+
+**Étapes**
+
+1. Consulter les journaux de l’ensemble du système :
+  ```shell
+  sudo journalctl
+  ```
+
+2. Consulter les journaux d’un service
+  ```shell
+  sudo journalctl -u haveged.service
+  ```
+
+- **Commandes utilisées** :
+    - `journalctl` : permet l’intéraction avec le service `journald` qui stocket les journaux des différents
+      services système
+
+---
+
+## 🏁 Challenge à valider
+
+Consultez le dossier [`challenge/`](./challenge/) pour réaliser un exercice
+final permettant de valider vos compétences à l'aide de tests automatisés.

--- a/tp-08-gerer_des_services/challenge/README.md
+++ b/tp-08-gerer_des_services/challenge/README.md
@@ -1,0 +1,45 @@
+# 🎯 Challenge final : Créer une configuration de service système
+
+## 📝 Objectif
+
+
+---
+
+## ✅ Étapes à effectuer
+
+1. **Créer un script qui sera exécuté en service système** : Le script va simplement afficher des lignes à l’aide de la commande `echo`
+2. **Créer une configuration systemd**
+3. **Activer le service au démarrage après un autre service**
+
+---
+
+## ⚙️ Contraintes
+
+- Le script ne doit utiliser **que les commandes basiques** `echo`, `date`, `while` et `sleep`
+- Le script doit afficher une ligne au format `Executed at <date> : <sortie du echo>` toutes les 10 secondes
+
+---
+
+## 📦 À rendre
+
+- Un script `systemd-unit-script.sh` (à créer).
+- Une configuration systemd `mytest-unit.service` au niveau système.
+    - Le service doit démarrer après le service `haveged`.
+    - Le service doit démarrer dans le contexte `multi-user`
+
+---
+
+## ▶️ Lancer les tests
+
+Depuis le dossier `challenge/` :
+
+```bash
+pytest -v
+```
+
+---
+
+## 🚫 Faire le ménage
+
+1. Arrêter votre service système
+2. Désactiver votre service système au démarrage

--- a/tp-08-gerer_des_services/challenge/test_tp.py
+++ b/tp-08-gerer_des_services/challenge/test_tp.py
@@ -1,0 +1,42 @@
+import testinfra
+
+
+def test_script_existe_et_non_vide(host):
+    f = host.file("systemd-unit-script.sh")
+    assert f.exists, "systemd-unit-script.sh n'existe pas"
+    assert f.size > 0, "systemd-unit-script.sh est vide"
+
+
+def test_systemd_unit_existe_et_non_vide(host):
+    f = host.file("/etc/systemd/system/mytest-unit.service")
+    assert f.exists, "/etc/systemd/system/mytest-unit.service n'existe pas"
+    assert f.size > 0, "/etc/systemd/system/mytest-unit.service est vide"
+
+
+def test_systemd_unit_existe_et_est_valide(host):
+    f = host.service("mytest-unit")
+    assert f.exists, "Le service mytest-unit.service n'existe pas"
+    assert f.is_valid, "Le service mytest-unit.service n’est pas valide"
+    assert f.systemd_properties[
+        "After"
+    ], "Le service mytest-unit.service ne contient pas de directive After"
+    assert (
+        "haveged.service" in f.systemd_properties["After"]
+    ), "Le service mytest-unit.service n’est pas dépendent du service haveged"
+
+
+def test_systemd_unit_et_demarre(host):
+    f = host.service("mytest-unit")
+    assert f.is_running, "Le service mytest-unit.service n'est pas demarre"
+
+
+def test_systemd_unit_et_actif_au_boot(host):
+    f = host.service("mytest-unit")
+    assert f.is_enabled, "Le service mytest-unit.service n'est pas actif au boot"
+
+
+def test_unit_logs_output(host):
+    logs = host.run("sudo journalctl -u mytest-unit.service")
+    assert (
+        "Executed" in logs.stdout
+    ), "Les journaux du service mytest-unit.service ne sont pas corrects"


### PR DESCRIPTION
# Module

Gestion des services systèmes avec `systemd`

# Tutoriel

- Manipuler des services avec `systemctl`
- Consulter les journaux avec `journalctl`

# Challenge

Créer un script qui sera exécuté en tant que service système via `systemd`

# Tests

- Teste si le script shell existe
- Test si l’unit systemd :
    - Existe
    - Est valide
    - À la propriété `After` définie
    - Est active
    - Est activée au démarrage du système
 - La sortie du script dans les journaux